### PR TITLE
A default value for a TEXT/BLOB field is not supported.

### DIFF
--- a/records/AmForms_SettingRecord.php
+++ b/records/AmForms_SettingRecord.php
@@ -15,7 +15,7 @@ class AmForms_SettingRecord extends BaseRecord
             'type'    => array(AttributeType::String, 'required' => true),
             'name'    => array(AttributeType::String, 'required' => true),
             'handle'  => array(AttributeType::String, 'required' => true),
-            'value'   => array(AttributeType::Mixed, 'default' => '')
+            'value'   => array(AttributeType::Mixed)
         );
     }
 


### PR DESCRIPTION
AttributeType::Mixed is converted to a text field.
This caused an error on install.

https://dev.mysql.com/doc/refman/5.0/en/blob.html

BLOB and TEXT columns cannot have DEFAULT values.