### PR TITLE
Global settings additions

### DIFF
--- a/AmFormsPlugin.php
+++ b/AmFormsPlugin.php
@@ -48,6 +48,14 @@ class AmFormsPlugin extends BasePlugin
     }
 
     /**
+     * @return string
+     */
+    public function getSettingsUrl()
+    {
+        return 'amforms/settings';
+    }
+
+    /**
      * @return Model
      */
     public function getSettings()

--- a/AmFormsPlugin.php
+++ b/AmFormsPlugin.php
@@ -9,6 +9,9 @@ namespace Craft;
 
 class AmFormsPlugin extends BasePlugin
 {
+    /**
+     * @return null|string
+     */
     public function getName()
     {
         if (craft()->plugins->getPlugin('amforms')) {
@@ -20,19 +23,86 @@ class AmFormsPlugin extends BasePlugin
         return Craft::t('a&m forms');
     }
 
+    /**
+     * @return string
+     */
     public function getVersion()
     {
         return '1.1.2';
     }
 
+    /**
+     * @return string
+     */
     public function getDeveloper()
     {
         return 'a&m impact';
     }
 
+    /**
+     * @return string
+     */
     public function getDeveloperUrl()
     {
         return 'http://www.am-impact.nl';
+    }
+
+    /**
+     * @return Model
+     */
+    public function getSettings()
+    {
+        $settings = craft()->amForms_settings->getAllSettings();
+        $settings = array_map(function (AmForms_SettingModel $settings) {
+            return  $settings->value;
+        }, $settings);
+
+        $settingsModel = new Model($settings);
+        $settingsModel->setAttributes($settings);
+
+        return $settingsModel;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param array|BaseModel $values
+     *
+     * @return null
+     */
+    public function setSettings($values)
+    {
+        if ($values)
+        {
+            if ($values instanceof BaseModel)
+            {
+                $values = $values->attributes;
+            }
+
+            // Get all available settings for this type
+            $availableSettings = craft()->amForms_settings->getAllSettings();
+
+            // Save each available setting
+            foreach ($availableSettings as $setting) {
+                // Find new settings
+                if (array_key_exists($setting->handle, $values)) {
+                    $setting->value = $values[$setting->handle];
+                    craft()->amForms_settings->saveSettings($setting);
+                }
+            }
+        }
+    }
+
+    /**
+     * @inheritdoc
+     * @param array $values
+     * @return Model
+     */
+    public function prepSettings($values)
+    {
+        $settingsModel = new Model($values);
+        $settingsModel->setAttributes($values);
+        return $settingsModel;
     }
 
     /**
@@ -117,7 +187,7 @@ class AmFormsPlugin extends BasePlugin
     public function registerUserPermissions()
     {
         return array(
-            'accessAmFormsExports'   => array(
+            'accessAmFormsExports' => array(
                 'label' => Craft::t('Access to exports')
             ),
             'accessAmFormsFields' => array(

--- a/AmFormsPlugin.php
+++ b/AmFormsPlugin.php
@@ -28,7 +28,7 @@ class AmFormsPlugin extends BasePlugin
      */
     public function getVersion()
     {
-        return '1.1.2';
+        return '1.1.3';
     }
 
     /**
@@ -175,6 +175,9 @@ class AmFormsPlugin extends BasePlugin
             ),
             'amforms/settings/recaptcha' => array(
                 'action' => 'amForms/settings/recaptcha'
+            ),
+            'amforms/settings/templates' => array(
+                'action' => 'amForms/settings/templates'
             )
         );
     }

--- a/controllers/AmForms_SettingsController.php
+++ b/controllers/AmForms_SettingsController.php
@@ -123,6 +123,10 @@ class AmForms_SettingsController extends BaseController
             }
         }
 
+        /** @var AmFormsPlugin $plugin */
+        $plugin = craft()->plugins->getPlugin('amForms');
+        craft()->plugins->savePluginSettings($plugin, $plugin->getSettings());
+
         if ($success) {
             craft()->userSession->setNotice(Craft::t('Settings saved.'));
         }

--- a/controllers/AmForms_SettingsController.php
+++ b/controllers/AmForms_SettingsController.php
@@ -66,6 +66,18 @@ class AmForms_SettingsController extends BaseController
     }
 
     /**
+     * Show reCAPTCHA settings.
+     */
+    public function actionTemplates()
+    {
+        $variables = array(
+            'type'      => AmFormsModel::SettingsTemplatePaths,
+            'templates' => craft()->amForms_settings->getAllSettingsByType(AmFormsModel::SettingsTemplatePaths)
+        );
+        $this->renderTemplate('amForms/settings/templates', $variables);
+    }
+
+    /**
      * Saves settings.
      */
     public function actionSaveSettings()

--- a/migrations/m151009_122433_amforms_addGlobalTemplateSettings.php
+++ b/migrations/m151009_122433_amforms_addGlobalTemplateSettings.php
@@ -1,0 +1,36 @@
+<?php
+namespace Craft;
+
+/**
+ * The class name is the UTC timestamp in the format of mYYMMDD_HHMMSS_pluginHandle_migrationName
+ */
+class m151009_122433_amforms_addGlobalTemplateSettings extends BaseMigration
+{
+	/**
+	 * Any migration code in here is wrapped inside of a transaction.
+	 *
+	 * @return bool
+	 */
+	public function safeUp()
+	{
+		$settings = array(
+			array(
+				'name' => 'Form template',
+				'value' => ''
+			),
+			array(
+				'name' => 'Tab template',
+				'value' => ''
+			),
+			array(
+				'name' => 'Field template',
+				'value' => ''
+			),
+			array(
+				'name' => 'Notification template',
+				'value' => ''
+			),
+		);
+		return craft()->amForms_install->installSettings($settings, AmFormsModel::SettingsTemplatePaths);
+	}
+}

--- a/models/AmFormsModel.php
+++ b/models/AmFormsModel.php
@@ -18,4 +18,5 @@ class AmFormsModel extends BaseModel
     const SettingExport = 'export';
     const SettingAntispam = 'antispam';
     const SettingRecaptcha = 'recaptcha';
+    const SettingsTemplatePaths = 'templates';
 }

--- a/services/AmFormsService.php
+++ b/services/AmFormsService.php
@@ -34,6 +34,11 @@ class AmFormsService extends BaseApplicationComponent
     {
         // Plugin's default template path
         $templatePath = craft()->path->getPluginsPath() . 'amforms/templates/_display/templates/';
+        $templateSetting = craft()->amForms_settings->getSettingsByHandleAndType($defaultTemplate . 'Template', AmFormsModel::SettingsTemplatePaths);
+
+        if (empty($overrideTemplate) && $templateSetting) {
+            $overrideTemplate = $templateSetting->value;
+        }
 
         // Is the override template set?
         if ($overrideTemplate) {

--- a/services/AmForms_InstallService.php
+++ b/services/AmForms_InstallService.php
@@ -16,6 +16,7 @@ class AmForms_InstallService extends BaseApplicationComponent
         $this->_installExport();
         $this->_installAntiSpam();
         $this->_installRecaptcha();
+        $this->_installTemplates();
         $this->_installFields();
     }
 
@@ -47,6 +48,7 @@ class AmForms_InstallService extends BaseApplicationComponent
             $settingRecord->value = $setting['value'];
             $settingRecord->save();
         }
+        return true;
     }
 
     /**
@@ -54,6 +56,7 @@ class AmForms_InstallService extends BaseApplicationComponent
      *
      * @param array  $settings
      * @param string $settingType
+     * @return bool
      */
     public function removeSettings(array $settings, $settingType)
     {
@@ -69,6 +72,7 @@ class AmForms_InstallService extends BaseApplicationComponent
                 craft()->amForms_settings->deleteSettingById($setting->id);
             }
         }
+        return true;
     }
 
     /**
@@ -189,6 +193,32 @@ class AmForms_InstallService extends BaseApplicationComponent
             )
         );
         $this->installSettings($settings, AmFormsModel::SettingRecaptcha);
+    }
+
+    /**
+     * Install gloval templates settings
+     */
+    private function _installTemplates()
+    {
+        $settings = array(
+            array(
+                'name' => 'Form template',
+                'value' => ''
+            ),
+            array(
+                'name' => 'Tab template',
+                'value' => ''
+            ),
+            array(
+                'name' => 'Field template',
+                'value' => ''
+            ),
+            array(
+                'name' => 'Notification template',
+                'value' => ''
+            ),
+        );
+        $this->installSettings($settings, AmFormsModel::SettingsTemplatePaths);
     }
 
     /**

--- a/services/AmForms_SettingsService.php
+++ b/services/AmForms_SettingsService.php
@@ -34,6 +34,15 @@ class AmForms_SettingsService extends BaseApplicationComponent
     }
 
     /**
+     * @return array
+     */
+    public function getAllSettings()
+    {
+        $settingRecords = AmForms_SettingRecord::model()->ordered()->findAll();
+        return AmForms_SettingModel::populateModels($settingRecords, 'handle');
+    }
+
+    /**
      * Get a setting by their handle and type.
      *
      * @param string $handle

--- a/templates/_layouts/settings.twig
+++ b/templates/_layouts/settings.twig
@@ -12,7 +12,8 @@
     general: { label: 'General'|t, url: url('amforms/settings') },
     exports: { label: 'Exports'|t, url: url('amforms/settings/exports') },
     antispam: { label: 'AntiSpam'|t, url: url('amforms/settings/antispam') },
-    recaptcha: { label: 'reCAPTCHA'|t, url: url('amforms/settings/recaptcha') }
+    recaptcha: { label: 'reCAPTCHA'|t, url: url('amforms/settings/recaptcha') },
+    templates: { label: 'Templates'|t, url: url('amforms/settings/templates') }
 } %}
 
 {% set content %}

--- a/templates/settings/templates.twig
+++ b/templates/settings/templates.twig
@@ -1,0 +1,42 @@
+{% extends 'amforms/_layouts/settings' %}
+
+{% set title = 'Templates'|t %}
+{% set selectedTab = 'templates' %}
+
+{% block fields %}
+    {{ forms.textField({
+        label: templates.formTemplate.name|t,
+        id: templates.formTemplate.handle,
+        name: templates.formTemplate.handle,
+        value: templates.formTemplate.value,
+        placeholder: '_amforms/form',
+        instructions: 'Override default template with your own template. Enter the folder (with template), e.g.: {template}'|t({'template': '_amforms'})
+    }) }}
+
+    {{ forms.textField({
+        label: templates.tabTemplate.name|t,
+        id: templates.tabTemplate.handle,
+        name: templates.tabTemplate.handle,
+        value: templates.tabTemplate.value,
+        placeholder: '_amforms/tab',
+        instructions: 'Override default template with your own template. Enter the folder (with template), e.g.: {template}'|t({'template': '_amforms'})
+    }) }}
+
+    {{ forms.textField({
+        label: templates.fieldTemplate.name|t,
+        id: templates.fieldTemplate.handle,
+        name: templates.fieldTemplate.handle,
+        value: templates.fieldTemplate.value,
+        placeholder: '_amforms/field',
+        instructions: 'Override default template with your own template. Enter the folder (with template), e.g.: {template}'|t({'template': '_amforms'})
+    }) }}
+
+    {{ forms.textField({
+        label: templates.notificationTemplate.name|t,
+        id: templates.notificationTemplate.handle,
+        name: templates.notificationTemplate.handle,
+        value: templates.notificationTemplate.value,
+        placeholder: '_amforms/email',
+        instructions: 'Override default template with your own template. Enter the folder (with template), e.g.: {template}'|t({'template': '_amforms'})
+    }) }}
+{% endblock %}


### PR DESCRIPTION
There are two additions here related to the settings.


**Added template settings to global settings**
There were settings to set the template path per form, we also added these to global settings to be able to set this path globally so we can override the templates for all forms. Reason being we would like to hide the more technical options of a form with permissions so that our clients could use it without breaking too much.

**Added getSettings and setSettings to plugin class**
Added a getSettings and setSettings method to the plugin class so that it follows the standard plugin pattern somewhat more. We also use the getSettings and setSettings methods to migrate plugin settings between environments.