### PR TITLE
Send e-mail copy

### DIFF
--- a/AmFormsPlugin.php
+++ b/AmFormsPlugin.php
@@ -28,7 +28,7 @@ class AmFormsPlugin extends BasePlugin
      */
     public function getVersion()
     {
-        return '1.2.0';
+        return '1.2.1';
     }
 
     /**

--- a/controllers/AmForms_FormsController.php
+++ b/controllers/AmForms_FormsController.php
@@ -111,6 +111,7 @@ class AmForms_FormsController extends BaseController
         $form->submitButton             = craft()->request->getPost('submitButton');
         $form->afterSubmitText          = craft()->request->getPost('afterSubmitText');
         $form->submissionEnabled        = craft()->request->getPost('submissionEnabled');
+        $form->sendCopy                 = craft()->request->getPost('sendCopy');
         $form->notificationEnabled      = craft()->request->getPost('notificationEnabled');
         $form->notificationFilesEnabled = craft()->request->getPost('notificationFilesEnabled');
         $form->notificationRecipients   = craft()->request->getPost('notificationRecipients');

--- a/controllers/AmForms_FormsController.php
+++ b/controllers/AmForms_FormsController.php
@@ -112,6 +112,7 @@ class AmForms_FormsController extends BaseController
         $form->afterSubmitText          = craft()->request->getPost('afterSubmitText');
         $form->submissionEnabled        = craft()->request->getPost('submissionEnabled');
         $form->sendCopy                 = craft()->request->getPost('sendCopy');
+        $form->sendCopyTo               = craft()->request->getPost('sendCopyTo');
         $form->notificationEnabled      = craft()->request->getPost('notificationEnabled');
         $form->notificationFilesEnabled = craft()->request->getPost('notificationFilesEnabled');
         $form->notificationRecipients   = craft()->request->getPost('notificationRecipients');

--- a/elementtypes/AmForms_FormElementType.php
+++ b/elementtypes/AmForms_FormElementType.php
@@ -167,6 +167,7 @@ class AmForms_FormElementType extends BaseElementType
                            forms.afterSubmitText,
                            forms.submissionEnabled,
                            forms.sendCopy,
+                           forms.sendCopyTo,
                            forms.notificationEnabled,
                            forms.notificationFilesEnabled,
                            forms.notificationRecipients,

--- a/elementtypes/AmForms_FormElementType.php
+++ b/elementtypes/AmForms_FormElementType.php
@@ -166,6 +166,7 @@ class AmForms_FormElementType extends BaseElementType
                            forms.submitButton,
                            forms.afterSubmitText,
                            forms.submissionEnabled,
+                           forms.sendCopy,
                            forms.notificationEnabled,
                            forms.notificationFilesEnabled,
                            forms.notificationRecipients,

--- a/fieldtypes/AmForms_EmailFieldType.php
+++ b/fieldtypes/AmForms_EmailFieldType.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Craft;
+
+/**
+ * Email fieldtype.
+ */
+class AmForms_EmailFieldType extends BaseFieldType
+{
+    /**
+     * @inheritDoc IComponentType::getName()
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return Craft::t('E-mail');
+    }
+
+    /**
+     * @inheritDoc IFieldType::defineContentAttribute()
+     *
+     * @return mixed
+     */
+    public function defineContentAttribute()
+    {
+        return AttributeType::Email;
+    }
+
+    /**
+     * @inheritDoc IFieldType::getInputHtml()
+     *
+     * @param string $name
+     * @param mixed  $value
+     *
+     * @return string
+     */
+    public function getInputHtml($name, $value)
+    {
+        return HtmlHelper::encodeParams('<input class="text fullwidth" type="email" name="{name}" value="{value}"/>', array('name' => $name, 'value' => $value));
+    }
+}

--- a/migrations/m151015_114827_amforms_addSendCopyToForm.php
+++ b/migrations/m151015_114827_amforms_addSendCopyToForm.php
@@ -14,6 +14,9 @@ class m151015_114827_amforms_addSendCopyToForm extends BaseMigration
      */
     public function safeUp()
     {
-        return $this->addColumnAfter('amforms_forms', 'sendCopy', array(AttributeType::Bool, 'default' => false), 'submissionEnabled');
+        $this->addColumnAfter('amforms_forms', 'sendCopyTo', AttributeType::String, 'submissionEnabled');
+        $this->addColumnAfter('amforms_forms', 'sendCopy', array(AttributeType::Bool, 'default' => false), 'submissionEnabled');
+
+        return true;
     }
 }

--- a/migrations/m151015_114827_amforms_addSendCopyToForm.php
+++ b/migrations/m151015_114827_amforms_addSendCopyToForm.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Craft;
+
+/**
+ * The class name is the UTC timestamp in the format of mYYMMDD_HHMMSS_pluginHandle_migrationName.
+ */
+class m151015_114827_amforms_addSendCopyToForm extends BaseMigration
+{
+    /**
+     * Any migration code in here is wrapped inside of a transaction.
+     *
+     * @return bool
+     */
+    public function safeUp()
+    {
+        return $this->addColumnAfter('amforms_forms', 'sendCopy', array(AttributeType::Bool, 'default' => false), 'submissionEnabled');
+    }
+}

--- a/models/AmForms_FormModel.php
+++ b/models/AmForms_FormModel.php
@@ -39,6 +39,7 @@ class AmForms_FormModel extends BaseElementModel
             'submitButton'             => AttributeType::String,
             'afterSubmitText'          => AttributeType::Mixed,
             'submissionEnabled'        => array(AttributeType::Bool, 'default' => true),
+            'sendCopy'                 => array(AttributeType::Bool, 'default' => false),
             'notificationEnabled'      => array(AttributeType::Bool, 'default' => true),
             'notificationFilesEnabled' => array(AttributeType::Bool, 'default' => false),
             'notificationRecipients'   => array(AttributeType::String, 'default' => $systemEmail),

--- a/models/AmForms_FormModel.php
+++ b/models/AmForms_FormModel.php
@@ -40,6 +40,7 @@ class AmForms_FormModel extends BaseElementModel
             'afterSubmitText'          => AttributeType::Mixed,
             'submissionEnabled'        => array(AttributeType::Bool, 'default' => true),
             'sendCopy'                 => array(AttributeType::Bool, 'default' => false),
+            'sendCopyTo'               => AttributeType::String,
             'notificationEnabled'      => array(AttributeType::Bool, 'default' => true),
             'notificationFilesEnabled' => array(AttributeType::Bool, 'default' => false),
             'notificationRecipients'   => array(AttributeType::String, 'default' => $systemEmail),

--- a/records/AmForms_FormRecord.php
+++ b/records/AmForms_FormRecord.php
@@ -28,6 +28,7 @@ class AmForms_FormRecord extends BaseRecord
             'submitButton'             => AttributeType::String,
             'afterSubmitText'          => AttributeType::Mixed,
             'submissionEnabled'        => array(AttributeType::Bool, 'default' => true),
+            'sendCopy'                 => array(AttributeType::Bool, 'default' => false),
             'notificationEnabled'      => array(AttributeType::Bool, 'default' => true),
             'notificationFilesEnabled' => array(AttributeType::Bool, 'default' => false),
             'notificationRecipients'   => AttributeType::String,

--- a/records/AmForms_FormRecord.php
+++ b/records/AmForms_FormRecord.php
@@ -29,6 +29,7 @@ class AmForms_FormRecord extends BaseRecord
             'afterSubmitText'          => AttributeType::Mixed,
             'submissionEnabled'        => array(AttributeType::Bool, 'default' => true),
             'sendCopy'                 => array(AttributeType::Bool, 'default' => false),
+            'sendCopyTo'               => AttributeType::String,
             'notificationEnabled'      => array(AttributeType::Bool, 'default' => true),
             'notificationFilesEnabled' => array(AttributeType::Bool, 'default' => false),
             'notificationRecipients'   => AttributeType::String,

--- a/services/AmForms_FieldsService.php
+++ b/services/AmForms_FieldsService.php
@@ -60,7 +60,8 @@ class AmForms_FieldsService extends BaseApplicationComponent
             'MultiSelect',
             'Number',
             'PlainText',
-            'RadioButtons'
+            'RadioButtons',
+            'AmForms_Email',
         );
     }
 

--- a/services/AmForms_SubmissionsService.php
+++ b/services/AmForms_SubmissionsService.php
@@ -302,6 +302,8 @@ class AmForms_SubmissionsService extends BaseApplicationComponent
                     $properBccAddresses = array();
 
                     foreach ($bccAddresses as $bccAddress) {
+                        $bccAddress = craft()->templates->renderObjectTemplate($bccAddress, $submission);
+
                         if (filter_var($bccAddress, FILTER_VALIDATE_EMAIL)) {
                             $properBccAddresses[] = array(
                                 'email' => $bccAddress

--- a/services/AmForms_SubmissionsService.php
+++ b/services/AmForms_SubmissionsService.php
@@ -234,6 +234,15 @@ class AmForms_SubmissionsService extends BaseApplicationComponent
 
         // Get our recipients
         $recipients = ArrayHelper::stringToArray($form->notificationRecipients);
+
+        // Send copy?
+        if ($form->sendCopy) {
+            $sendCopyTo = $submission->{$form->sendCopyTo};
+            if (filter_var($sendCopyTo, FILTER_VALIDATE_EMAIL)) {
+                $recipients[] = $sendCopyTo;
+            }
+        }
+
         if ($overrideRecipients !== false) {
             if (is_array($overrideRecipients) && count($overrideRecipients)) {
                 $recipients = $overrideRecipients;

--- a/templates/forms/_fields/form.twig
+++ b/templates/forms/_fields/form.twig
@@ -89,8 +89,20 @@
     onLabel: 'Enable'|t,
     offLabel: 'Disable'|t,
     errors: form.getErrors('sendCopy'),
-    instructions: 'Whether to send a copy to the submitter.'|t
+    instructions: 'Whether to send a copy to the submitter.'|t,
+    toggle: 'sendCopyTo-container'
 }) }}
+<div class="hidden" id="sendCopyTo-container">
+    {{ forms.selectField({
+        label: "Send copy to"|t,
+        instructions: "Please select an e-mail field."|t,
+        warning: "The value of this field should be an e-mailaddress."|t,
+        id: 'sendCopyTo',
+        name: 'sendCopyTo',
+        options: craft.amForms.getFieldHandles(),
+        value: form.sendCopyTo
+    }) }}
+</div>
 {% if not currentUser.admin %}
     <div class="hidden">
 {% endif %}

--- a/templates/forms/_fields/form.twig
+++ b/templates/forms/_fields/form.twig
@@ -81,6 +81,16 @@
     errors: form.getErrors('submissionEnabled'),
     instructions: 'Whether to store form submissions.'|t
 }) }}
+{{ forms.lightswitchField({
+    label: 'Send copy'|t,
+    id: 'sendCopy',
+    name: 'sendCopy',
+    on: form.sendCopy,
+    onLabel: 'Enable'|t,
+    offLabel: 'Disable'|t,
+    errors: form.getErrors('sendCopy'),
+    instructions: 'Whether to send a copy to the submitter.'|t
+}) }}
 {% if not currentUser.admin %}
     <div class="hidden">
 {% endif %}

--- a/translations/nl.php
+++ b/translations/nl.php
@@ -132,6 +132,8 @@ return array(
     'Restart' => 'Herstarten',
     'Save and start' => 'Bewaren en uitvoeren',
     'Save submissions' => 'Inzendingen opslaan',
+    'Send copy' => 'Verstuur kopie',
+    'Whether to send a copy to the submitter.' => 'Of er een kopie naar de inzender verstuurd moet worden.',
     'Secret key' => 'Geheime sleutel',
     'Select a page' => 'Selecteer een pagina',
     'Send notifications' => 'Notificaties versturen',

--- a/variables/AmFormsVariable.php
+++ b/variables/AmFormsVariable.php
@@ -28,6 +28,22 @@ class AmFormsVariable
     }
 
     /**
+     * Get field handles.
+     *
+     * @return array
+     */
+    public function getFieldHandles()
+    {
+        $handles = array();
+        $fields = craft()->fields->getAllFields('handle', AmFormsModel::FieldContext);
+        foreach ($fields as $field) {
+            $handles[] = array('label' => $field->name, 'value' => $field->handle);
+        }
+
+        return $handles;
+    }
+
+    /**
      * Returns a criteria model for AmForms_Submission elements.
      *
      * @param array $attributes


### PR DESCRIPTION
__Added "Send Copy" functionality__
* Adds Send Copy lightswitch to the form creator
* Clicking that will reveal a Send Copy To select field, containing all the amforms fields
* Here you can select a field representing an e-mailaddress value
* When switched on, a copy will be sent to this e-mailaddress

__Added an e-mail fieldtype with e-mail validation__
* Plaintext field with [input type="email"] and Craft e-mail model validation
* Added for easy use with the Send Copy functionality

__Added support for submission object parsing in BCC addresses__
* So you can use {emailHandle} in BCC addresses too