### PR TITLE
Use formhandle for submitted param

### DIFF
--- a/controllers/AmForms_SubmissionsController.php
+++ b/controllers/AmForms_SubmissionsController.php
@@ -306,7 +306,7 @@ class AmForms_SubmissionsController extends BaseController
         $url = null;
         $redirectUrl = $submission->getForm()->getRedirectUrl();
         if (empty($redirectUrl)) {
-            $url = craft()->request->getPath() . '?submitted=' . ($submitted ? 1 : 0);
+            $url = craft()->request->getPath() . '?submitted=' . ($submitted ? $submission->getForm()->handle : 0);
         }
 
         $this->redirectToPostedUrl($vars, $url);

--- a/templates/_display/templates/form.twig
+++ b/templates/_display/templates/form.twig
@@ -1,4 +1,4 @@
-{% if craft.request.getParam('submitted') %}
+{% if craft.request.getParam('submitted') == form.handle %}
     <p>{{ form.afterSubmitText|default('Thanks for your submission.'|t) }}</p>
 {% else %}
     {%- set submitValue = (form.submitButton ? form.submitButton : 'Submit'|t) -%}


### PR DESCRIPTION
In stead of 1 set the formHandle on the submitted param.
Allows you to see which form has been submitted in case of multiple forms on a page.