### PR TITLE
The email template setting is called notificationTemplate, not emailTemplate

### DIFF
--- a/services/AmFormsService.php
+++ b/services/AmFormsService.php
@@ -59,7 +59,9 @@ class AmFormsService extends BaseApplicationComponent
     {
         // Plugin's default template path
         $templatePath = craft()->path->getPluginsPath() . 'amforms/templates/_display/templates/';
-        $templateSetting = craft()->amForms_settings->getSettingsByHandleAndType($defaultTemplate . 'Template', AmFormsModel::SettingsTemplatePaths);
+
+        $settingsName = $defaultTemplate == 'email' ? 'notificationTemplate' : $defaultTemplate . 'Template';
+        $templateSetting = craft()->amForms_settings->getSettingsByHandleAndType($settingsName, AmFormsModel::SettingsTemplatePaths);
 
         if (empty($overrideTemplate) && $templateSetting) {
             $overrideTemplate = $templateSetting->value;


### PR DESCRIPTION
Fixed Aa error in determining the name of the global template setting for emails.