### PR TITLE
Handle the required attribute in the field templates.

### DIFF
--- a/services/AmForms_FormsService.php
+++ b/services/AmForms_FormsService.php
@@ -318,11 +318,10 @@ class AmForms_FormsService extends BaseApplicationComponent
                 // Reset templates path for input and get field input
                 craft()->path->setTemplatesPath($pluginTemplatePath);
                 $fieldInfo = craft()->fields->populateFieldType($field, $submission);
+
+                craft()->templates->getTwig()->addGlobal('required', $layoutField->required);
                 $input = $fieldInfo->getInputHtml($field->handle, $submission->getFieldValue($field->handle));
-                if ($layoutField->required) {
-                    $fieldId = sprintf('name="%s"', $field->handle);
-                    $input = str_replace($fieldId, $fieldId . ' required', $input);
-                }
+                craft()->templates->getTwig()->addGlobal('required', null);
 
                 // Get field HTML
                 craft()->path->setTemplatesPath($fieldTemplateInfo['path']);

--- a/templates/_display/templates/_components/fieldtypes/Assets/input.twig
+++ b/templates/_display/templates/_components/fieldtypes/Assets/input.twig
@@ -4,4 +4,5 @@
         {%- if name is defined %} name="{{ name }}{% if limit is not defined or not limit or limit > 1 %}[]{% endif %}"{% endif %}
         {%- if autofocus is defined and autofocus and not craft.request.isMobileBrowser(true) %} autofocus{% endif %}
         {%- if limit is not defined or not limit or limit > 1 %} multiple{% endif %}
-        {%- if disabled is defined and disabled %} disabled{% endif %}>
+        {%- if disabled is defined and disabled %} disabled{% endif %}
+        {%- if required is defined and required %} required {% endif %}>

--- a/templates/_display/templates/_includes/forms/color.html
+++ b/templates/_display/templates/_includes/forms/color.html
@@ -7,7 +7,8 @@
 	{%- if name is defined %} name="{{ name }}"{% endif %}
 	{%- if value is defined %} value="{{ value }}"{% endif %}
 	{%- if autofocus is defined and autofocus and not craft.request.isMobileBrowser(true) %} autofocus{% endif %}
-	{%- if disabled is defined and disabled %} disabled {% endif %}>
+	{%- if disabled is defined and disabled %} disabled {% endif %}
+    {%- if required is defined and required %} required {% endif %}>
 
 {%- includeJsResource "lib/colorpicker/js/colorpicker.js" -%}
 {%- includeCssResource "lib/colorpicker/css/colorpicker.css" -%}

--- a/templates/_display/templates/_includes/forms/file.html
+++ b/templates/_display/templates/_includes/forms/file.html
@@ -3,4 +3,5 @@
 	{%- if class is defined %} class="{{ class }}"{% endif %}
 	{%- if name is defined %} name="{{ name }}"{% endif %}
 	{%- if autofocus is defined and autofocus and not craft.request.isMobileBrowser(true) %} autofocus{% endif %}
-	{%- if disabled is defined and disabled %} disabled{% endif %}>
+	{%- if disabled is defined and disabled %} disabled{% endif %}
+    {%- if required is defined and required %} required {% endif %}>

--- a/templates/_display/templates/_includes/forms/radio.html
+++ b/templates/_display/templates/_includes/forms/radio.html
@@ -7,6 +7,7 @@
 		{%- if name is defined %} name="{{ name }}"{% endif %}
 		{%- if checked is defined and checked %} checked{% endif %}
 		{%- if autofocus is defined and autofocus and not craft.request.isMobileBrowser(true) %} autofocus{% endif %}
-		{%- if disabled is defined and disabled %} disabled{% endif %}>
+		{%- if disabled is defined and disabled %} disabled{% endif %}
+        {%- if required is defined and required %} required {% endif %}>
 	{% if label is defined %}{{ label|raw }}{% endif %}
 </label>

--- a/templates/_display/templates/_includes/forms/select.html
+++ b/templates/_display/templates/_includes/forms/select.html
@@ -14,7 +14,8 @@
 		{%- if name is defined %} name="{{ name }}"{% endif %}
 		{%- if autofocus is defined and autofocus and not craft.request.isMobileBrowser(true) %} autofocus{% endif %}
 		{%- if disabled is defined and disabled %} disabled{% endif %}
-		{%- if targetPrefix is defined %} data-target-prefix="{{ targetPrefix }}"{% endif %}>
+		{%- if targetPrefix is defined %} data-target-prefix="{{ targetPrefix }}"{% endif %}
+        {%- if required is defined and required %} required {% endif %}>
 		{% for key, option in options %}
 			{% if option.optgroup is defined %}
 				{% if hasOptgroups %}

--- a/templates/_display/templates/_includes/forms/text.html
+++ b/templates/_display/templates/_includes/forms/text.html
@@ -26,5 +26,6 @@
 	{%- if autocomplete is not defined or not autocomplete %} autocomplete="off"{% endif %}
 	{%- if disabled is defined and disabled %} disabled {% endif %}
 	{%- if readonly is defined and readonly %} readonly {% endif %}
-	{%- if placeholder is defined %} placeholder="{{ placeholder }}"{% endif %}>
+	{%- if placeholder is defined %} placeholder="{{ placeholder }}"{% endif %}
+    {%- if required is defined and required %} required {% endif %}>
 {%- if type == 'password' %}</div>{% endif %}

--- a/templates/_display/templates/_includes/forms/textarea.html
+++ b/templates/_display/templates/_includes/forms/textarea.html
@@ -15,4 +15,5 @@
 	{%- if showCharsLeft is defined and showCharsLeft %} data-show-chars-left{% endif %}
 	{%- if autofocus is defined and autofocus and not craft.request.isMobileBrowser(true) %} autofocus{% endif %}
 	{%- if disabled is defined and disabled %} disabled{% endif %}
-	{%- if placeholder is defined %} placeholder="{{ placeholder }}"{% endif %}>{{ value is defined ? value : null }}</textarea>
+	{%- if placeholder is defined %} placeholder="{{ placeholder }}"{% endif %}
+    {%- if required is defined and required %} required {% endif %}>{{ value is defined ? value : null }}</textarea>


### PR DESCRIPTION
Sadly it is not possible to pass a required param to getInputHtml.
Therefore the variable is set globally before it is needed and unset afterwards.
This allows for more customization in the templates, for instance when frontend validation is needed for checkboxes. The string replace did not work for all field types.