### PR TITLE
Placeholder on Email FieldType

### DIFF
--- a/fieldtypes/AmForms_EmailFieldType.php
+++ b/fieldtypes/AmForms_EmailFieldType.php
@@ -16,6 +16,18 @@ class AmForms_EmailFieldType extends BaseFieldType
     {
         return Craft::t('E-mail');
     }
+    
+    /**
+    * @inheritDoc ISavableComponentType::getSettingsHtml()
+    *
+    * @return string|null
+    */
+    public function getSettingsHtml()
+    {
+        return craft()->templates->render('amforms/_display/templates/_components/fieldtypes/PlainText/settings', array(
+          'settings' => $this->getSettings()
+        ));
+    }
 
     /**
      * @inheritDoc IFieldType::defineContentAttribute()

--- a/templates/_display/templates/_components/fieldtypes/PlainText/settings.twig
+++ b/templates/_display/templates/_components/fieldtypes/PlainText/settings.twig
@@ -1,0 +1,11 @@
+{% import "_includes/forms" as forms %}
+
+{{ forms.textField({
+	label: "Placeholder Text"|t,
+    instructions: "The text that will be shown if the field doesn’t have a value."|t,
+	id: 'placeholder',
+	name: 'placeholder',
+	value: settings.placeholder,
+	translatable: true,
+	errors: settings.getErrors('placeholder')
+}) }}


### PR DESCRIPTION
I'm pretty sure this is all that's need to make the placeholder input available on the email fieldtype.
fixes #27, fixes #56 