### PR TITLE
Fix issues regarding templates

### DIFF
--- a/services/AmFormsService.php
+++ b/services/AmFormsService.php
@@ -79,9 +79,9 @@ class AmFormsService extends BaseApplicationComponent
                 // Try to find the template for each available template extension
                 foreach (craft()->config->get('defaultTemplateExtensions') as $extension) {
                     if (IOHelper::fileExists($templateFile . '.' . $extension)) {
-                        $pathParts = explode('/', $overrideTemplate);
-                        $defaultTemplate = $pathParts[ (count($pathParts) - 1) ];
-                        $templatePath = craft()->path->getSiteTemplatesPath() . implode('/', array_slice($pathParts, 0, (count($pathParts) - 1)));
+                        $defaultTemplate = $overrideTemplate;
+                        $templatePath = craft()->path->getSiteTemplatesPath();
+                        break;
                     }
                 }
             }

--- a/services/AmForms_SubmissionsService.php
+++ b/services/AmForms_SubmissionsService.php
@@ -421,7 +421,13 @@ class AmForms_SubmissionsService extends BaseApplicationComponent
             'form' => $form,
             'submission' => $submission
         );
-        return craft()->amForms->renderDisplayTemplate('confirmation', $form->confirmationTemplate, $variables);
+
+        $overrideTemplate = $form->confirmationTemplate;
+        if (empty($overrideTemplate)) {
+            $overrideTemplate = $form->notificationTemplate;
+        }
+
+        return craft()->amForms->renderDisplayTemplate('confirmation', $overrideTemplate, $variables);
     }
 
     /**


### PR DESCRIPTION
1. Changing the load custom template method to use Craft's frontend template path. Extends and includes could (and should) be relative to the default templates folder. This is how Craft is working by default too.

2. Secondly changed the new confirmation email template setting. From the previous version, you could have set up a notification email template, which now becomes the only mail to the admin-user. The mail to the client becomes default again.
When the new confirmation email template setting is not set, use the notification email template instead. Now backwards compatible.