### PR TITLE
Add confirmation template to default config

### DIFF
--- a/AmFormsPlugin.php
+++ b/AmFormsPlugin.php
@@ -33,7 +33,7 @@ class AmFormsPlugin extends BasePlugin
      */
     public function getVersion()
     {
-        return '1.6.0';
+        return '1.6.1';
     }
 
     /**

--- a/config.php
+++ b/config.php
@@ -101,6 +101,10 @@ return array(
             'name' => 'Notification template',
             'value' => '',
         ),
+        array(
+            'name' => 'Confirmation template',
+            'value' => '',
+        ),
     ),
     'fields' => array(
         array(

--- a/releases.json
+++ b/releases.json
@@ -1,5 +1,13 @@
 [
     {
+        "version": "1.6.1",
+        "downloadUrl": "https://github.com/am-impact/amforms/archive/master.zip",
+        "date": "2016-10-25T10:00:00+01:00",
+        "notes": [
+            "[Fixed] Fixed pull request that missed an attribute in the form record."
+        ]
+    },
+    {
         "version": "1.6.0",
         "downloadUrl": "https://github.com/am-impact/amforms/archive/master.zip",
         "date": "2016-10-18T10:00:00+01:00",


### PR DESCRIPTION
Adds the missing 'Confirmation template' setting to the default configuration for new installations. This fixes #109.