### PR TITLE
assetSettings path key exists check in getPathForAsset

### DIFF
--- a/services/AmFormsService.php
+++ b/services/AmFormsService.php
@@ -38,6 +38,9 @@ class AmFormsService extends BaseApplicationComponent
             $assetFolder = craft()->assets->getFolderById($asset->folderId);
             $assetSource = $assetFolder->getSource();
             $assetSettings = $assetSource->settings;
+            if (!array_key_exists('path', $assetSettings)) {
+                $assetSettings['path'] = '';
+            }
             if ($assetFolder->path) {
                 $assetSettings['path'] = $assetSettings['path'] . $assetFolder->path;
             }


### PR DESCRIPTION
Sometimes the path setting is not filled, especially when using s3.
This check makes it so that the script at least doesn't crash on a missing array key and the export can continue.